### PR TITLE
Fix "cannot read property '0' of undefined" in case of lost data race

### DIFF
--- a/as-nav-for.js
+++ b/as-nav-for.js
@@ -78,7 +78,7 @@ proto.setNavCompanion = function( elem ) {
 };
 
 proto.navCompanionSelect = function( isInstant ) {
-  if ( !this.navCompanion ) {
+  if ( !this.navCompanion || !this.navCompanion.selectedCells ) {
     return;
   }
   // select slide that matches first cell of slide


### PR DESCRIPTION
We are using flickity together with another widget/ui framwork. This seems to cause some kind of data race where the navCompanion is not really "ready" when the first navCompanionSelect happens. 
When this happes `navCompanion.selectedCells` is still undefined and accessing it throws an TypeError. This check prevents that. On our tests it behaves exactly the same as before, but without throwing the error.